### PR TITLE
variable segment list

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,8 @@ TODO:
 * OPERATOR might not be the best name for what is really event handlers, analogous to RD stored-proc stuff
 
 
+# GEN API DOCS
+
+```
+widdershins --environment reference/env.json reference/dtlab-alligator.v1.yaml reference/README.md
+```

--- a/examples/actors.rest
+++ b/examples/actors.rest
@@ -1,4 +1,4 @@
-http://localhost:8080
+http://localhost:8081
 #https://somind.tech
 #https://somind.org
 
@@ -14,6 +14,13 @@ GET /dtlab-alligator/actor/badmachine/one/badmodule/2
 
 --
 GET /dtlab-alligator/actor/machine/one/module/2/submodule/three
+
+--
+POST /dtlab-alligator/actor/badmachine/one/badmodule/2/
+{
+  "idx": 1,
+  "value": 2.2
+}
 
 --
 POST /dtlab-alligator/actor/badmachine/one/badmodule/2/

--- a/examples/types.rest
+++ b/examples/types.rest
@@ -13,7 +13,7 @@ GET /dtlab-alligator/type/machinery
 GET /dtlab-alligator/type/badmodule
 
 --
-POST /dtlab-alligator/type/machinery1
+POST /dtlab-alligator/type/machinery66
 {
   "props": ["temp", "speed"],
   "children": ["alternator_module", "starter_module"]

--- a/reference/README.md
+++ b/reference/README.md
@@ -1,14 +1,10 @@
 ---
 title: dtlab alligator v1.0
 language_tabs:
-  - shell: Shell
-  - http: HTTP
-  - javascript: JavaScript
-  - ruby: Ruby
   - python: Python
-  - php: PHP
+  - shell: Shell
+  - javascript: Javascript
   - java: Java
-  - go: Go
 toc_footers: []
 includes: []
 search: true
@@ -40,19 +36,24 @@ License: <a href="https://github.com/SoMind/dtlab-scala-alligator/blob/master/LI
 
 > Code samples
 
+```python
+import requests
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+
+r = requests.post('http://localhost:8081/dtlab-alligator/type/{typename}', headers = headers)
+
+print(r.json())
+
+```
+
 ```shell
 # You can also use wget
 curl -X POST http://localhost:8081/dtlab-alligator/type/{typename} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json'
-
-```
-
-```http
-POST http://localhost:8081/dtlab-alligator/type/{typename} HTTP/1.1
-Host: localhost:8081
-Content-Type: application/json
-Accept: application/json
 
 ```
 
@@ -86,68 +87,6 @@ fetch('http://localhost:8081/dtlab-alligator/type/{typename}',
 
 ```
 
-```ruby
-require 'rest-client'
-require 'json'
-
-headers = {
-  'Content-Type' => 'application/json',
-  'Accept' => 'application/json'
-}
-
-result = RestClient.post 'http://localhost:8081/dtlab-alligator/type/{typename}',
-  params: {
-  }, headers: headers
-
-p JSON.parse(result)
-
-```
-
-```python
-import requests
-headers = {
-  'Content-Type': 'application/json',
-  'Accept': 'application/json'
-}
-
-r = requests.post('http://localhost:8081/dtlab-alligator/type/{typename}', headers = headers)
-
-print(r.json())
-
-```
-
-```php
-<?php
-
-require 'vendor/autoload.php';
-
-$headers = array(
-    'Content-Type' => 'application/json',
-    'Accept' => 'application/json',
-);
-
-$client = new \GuzzleHttp\Client();
-
-// Define array of request body.
-$request_body = array();
-
-try {
-    $response = $client->request('POST','http://localhost:8081/dtlab-alligator/type/{typename}', array(
-        'headers' => $headers,
-        'json' => $request_body,
-       )
-    );
-    print_r($response->getBody()->getContents());
- }
- catch (\GuzzleHttp\Exception\BadResponseException $e) {
-    // handle exception or api errors.
-    print_r($e->getMessage());
- }
-
- // ...
-
-```
-
 ```java
 URL obj = new URL("http://localhost:8081/dtlab-alligator/type/{typename}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
@@ -162,32 +101,6 @@ while ((inputLine = in.readLine()) != null) {
 }
 in.close();
 System.out.println(response.toString());
-
-```
-
-```go
-package main
-
-import (
-       "bytes"
-       "net/http"
-)
-
-func main() {
-
-    headers := map[string][]string{
-        "Content-Type": []string{"application/json"},
-        "Accept": []string{"application/json"},
-    }
-
-    data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("POST", "http://localhost:8081/dtlab-alligator/type/{typename}", data)
-    req.Header = headers
-
-    client := &http.Client{}
-    resp, err := client.Do(req)
-    // ...
-}
 
 ```
 
@@ -257,17 +170,22 @@ This operation does not require authentication
 
 > Code samples
 
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://localhost:8081/dtlab-alligator/type/{typename}', headers = headers)
+
+print(r.json())
+
+```
+
 ```shell
 # You can also use wget
 curl -X GET http://localhost:8081/dtlab-alligator/type/{typename} \
   -H 'Accept: application/json'
-
-```
-
-```http
-GET http://localhost:8081/dtlab-alligator/type/{typename} HTTP/1.1
-Host: localhost:8081
-Accept: application/json
 
 ```
 
@@ -291,65 +209,6 @@ fetch('http://localhost:8081/dtlab-alligator/type/{typename}',
 
 ```
 
-```ruby
-require 'rest-client'
-require 'json'
-
-headers = {
-  'Accept' => 'application/json'
-}
-
-result = RestClient.get 'http://localhost:8081/dtlab-alligator/type/{typename}',
-  params: {
-  }, headers: headers
-
-p JSON.parse(result)
-
-```
-
-```python
-import requests
-headers = {
-  'Accept': 'application/json'
-}
-
-r = requests.get('http://localhost:8081/dtlab-alligator/type/{typename}', headers = headers)
-
-print(r.json())
-
-```
-
-```php
-<?php
-
-require 'vendor/autoload.php';
-
-$headers = array(
-    'Accept' => 'application/json',
-);
-
-$client = new \GuzzleHttp\Client();
-
-// Define array of request body.
-$request_body = array();
-
-try {
-    $response = $client->request('GET','http://localhost:8081/dtlab-alligator/type/{typename}', array(
-        'headers' => $headers,
-        'json' => $request_body,
-       )
-    );
-    print_r($response->getBody()->getContents());
- }
- catch (\GuzzleHttp\Exception\BadResponseException $e) {
-    // handle exception or api errors.
-    print_r($e->getMessage());
- }
-
- // ...
-
-```
-
 ```java
 URL obj = new URL("http://localhost:8081/dtlab-alligator/type/{typename}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
@@ -364,31 +223,6 @@ while ((inputLine = in.readLine()) != null) {
 }
 in.close();
 System.out.println(response.toString());
-
-```
-
-```go
-package main
-
-import (
-       "bytes"
-       "net/http"
-)
-
-func main() {
-
-    headers := map[string][]string{
-        "Accept": []string{"application/json"},
-    }
-
-    data := bytes.NewBuffer([]byte{jsonReq})
-    req, err := http.NewRequest("GET", "http://localhost:8081/dtlab-alligator/type/{typename}", data)
-    req.Header = headers
-
-    client := &http.Client{}
-    resp, err := client.Do(req)
-    // ...
-}
 
 ```
 

--- a/reference/README.md
+++ b/reference/README.md
@@ -1,0 +1,498 @@
+---
+title: dtlab alligator v1.0
+language_tabs:
+  - shell: Shell
+  - http: HTTP
+  - javascript: JavaScript
+  - ruby: Ruby
+  - python: Python
+  - php: PHP
+  - java: Java
+  - go: Go
+toc_footers: []
+includes: []
+search: true
+highlight_theme: darkula
+headingLevel: 2
+
+---
+
+<!-- Generator: Widdershins v4.0.1 -->
+
+<h1 id="dtlab-alligator">dtlab alligator v1.0</h1>
+
+> Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
+
+manage DtLab actor runtime cloud
+
+Base URLs:
+
+* <a href="http://localhost:8081">http://localhost:8081</a>
+
+Email: <a href="mailto:ed@onextent.com">navicore</a> 
+License: <a href="https://github.com/SoMind/dtlab-scala-alligator/blob/master/LICENSE">MIT</a>
+
+<h1 id="dtlab-alligator-create">create</h1>
+
+## post-dtlab-alligator-type-typename
+
+<a id="opIdpost-dtlab-alligator-type-typename"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X POST http://localhost:8081/dtlab-alligator/type/{typename} \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json'
+
+```
+
+```http
+POST http://localhost:8081/dtlab-alligator/type/{typename} HTTP/1.1
+Host: localhost:8081
+Content-Type: application/json
+Accept: application/json
+
+```
+
+```javascript
+const inputBody = '{
+  "props": [
+    "temp",
+    "speed"
+  ],
+  "children": [
+    "alternator_module",
+    "starter_module"
+  ]
+}';
+const headers = {
+  'Content-Type':'application/json',
+  'Accept':'application/json'
+};
+
+fetch('http://localhost:8081/dtlab-alligator/type/{typename}',
+{
+  method: 'POST',
+  body: inputBody,
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Content-Type' => 'application/json',
+  'Accept' => 'application/json'
+}
+
+result = RestClient.post 'http://localhost:8081/dtlab-alligator/type/{typename}',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+
+r = requests.post('http://localhost:8081/dtlab-alligator/type/{typename}', headers = headers)
+
+print(r.json())
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Content-Type' => 'application/json',
+    'Accept' => 'application/json',
+);
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('POST','http://localhost:8081/dtlab-alligator/type/{typename}', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://localhost:8081/dtlab-alligator/type/{typename}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("POST");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Content-Type": []string{"application/json"},
+        "Accept": []string{"application/json"},
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("POST", "http://localhost:8081/dtlab-alligator/type/{typename}", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`POST /dtlab-alligator/type/{typename}`
+
+*create type*
+
+create a new type with property names and allowable children types
+
+> Body parameter
+
+```json
+{
+  "props": [
+    "temp",
+    "speed"
+  ],
+  "children": [
+    "alternator_module",
+    "starter_module"
+  ]
+}
+```
+
+<h3 id="post-dtlab-alligator-type-typename-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[CreateTypeRequest](#schemacreatetyperequest)|false|a copy of the successfully created type definition|
+|typename|path|string|true|the name of the type that can show up in a path|
+
+> Example responses
+
+> 201 Response
+
+```json
+{
+  "name": "string",
+  "created": "string",
+  "props": [
+    "string"
+  ],
+  "children": [
+    "string"
+  ]
+}
+```
+
+<h3 id="post-dtlab-alligator-type-typename-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|If successfully created, returned object will be updated with typename and create datetime|[Type](#schematype)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict - you must delete the previous entry before creating a type of the same name.|Inline|
+
+<h3 id="post-dtlab-alligator-type-typename-responseschema">Response Schema</h3>
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+<h1 id="dtlab-alligator-ask">ask</h1>
+
+## get-dtlab-alligator-typename
+
+<a id="opIdget-dtlab-alligator-typename"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://localhost:8081/dtlab-alligator/type/{typename} \
+  -H 'Accept: application/json'
+
+```
+
+```http
+GET http://localhost:8081/dtlab-alligator/type/{typename} HTTP/1.1
+Host: localhost:8081
+Accept: application/json
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+};
+
+fetch('http://localhost:8081/dtlab-alligator/type/{typename}',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+headers = {
+  'Accept' => 'application/json'
+}
+
+result = RestClient.get 'http://localhost:8081/dtlab-alligator/type/{typename}',
+  params: {
+  }, headers: headers
+
+p JSON.parse(result)
+
+```
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://localhost:8081/dtlab-alligator/type/{typename}', headers = headers)
+
+print(r.json())
+
+```
+
+```php
+<?php
+
+require 'vendor/autoload.php';
+
+$headers = array(
+    'Accept' => 'application/json',
+);
+
+$client = new \GuzzleHttp\Client();
+
+// Define array of request body.
+$request_body = array();
+
+try {
+    $response = $client->request('GET','http://localhost:8081/dtlab-alligator/type/{typename}', array(
+        'headers' => $headers,
+        'json' => $request_body,
+       )
+    );
+    print_r($response->getBody()->getContents());
+ }
+ catch (\GuzzleHttp\Exception\BadResponseException $e) {
+    // handle exception or api errors.
+    print_r($e->getMessage());
+ }
+
+ // ...
+
+```
+
+```java
+URL obj = new URL("http://localhost:8081/dtlab-alligator/type/{typename}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+```go
+package main
+
+import (
+       "bytes"
+       "net/http"
+)
+
+func main() {
+
+    headers := map[string][]string{
+        "Accept": []string{"application/json"},
+    }
+
+    data := bytes.NewBuffer([]byte{jsonReq})
+    req, err := http.NewRequest("GET", "http://localhost:8081/dtlab-alligator/type/{typename}", data)
+    req.Header = headers
+
+    client := &http.Client{}
+    resp, err := client.Do(req)
+    // ...
+}
+
+```
+
+`GET /dtlab-alligator/type/{typename}`
+
+*get type*
+
+Look up a type definition.
+
+<h3 id="get-dtlab-alligator-typename-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|typename|path|string|true|the name of the type that can show up in a path|
+
+> Example responses
+
+> Definition of the type
+
+```json
+{
+  "children": [
+    "alternator_module",
+    "starter_module"
+  ],
+  "created": "2020-07-23T01:30:24.783Z",
+  "name": "machinery1",
+  "props": [
+    "temp",
+    "speed"
+  ]
+}
+```
+
+<h3 id="get-dtlab-alligator-typename-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Definition of the type|[Type](#schematype)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|None|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+# Schemas
+
+<h2 id="tocS_CreateTypeRequest">CreateTypeRequest</h2>
+<!-- backwards compatibility -->
+<a id="schemacreatetyperequest"></a>
+<a id="schema_CreateTypeRequest"></a>
+<a id="tocScreatetyperequest"></a>
+<a id="tocscreatetyperequest"></a>
+
+```json
+{
+  "props": [
+    "string"
+  ],
+  "children": [
+    "string"
+  ]
+}
+
+```
+
+CreateTypeRequest
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|props|[string]|false|none|none|
+|children|[string]|false|none|none|
+
+<h2 id="tocS_Type">Type</h2>
+<!-- backwards compatibility -->
+<a id="schematype"></a>
+<a id="schema_Type"></a>
+<a id="tocStype"></a>
+<a id="tocstype"></a>
+
+```json
+{
+  "name": "string",
+  "created": "string",
+  "props": [
+    "string"
+  ],
+  "children": [
+    "string"
+  ]
+}
+
+```
+
+Type
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|name|string|false|none|none|
+|created|string|false|none|none|
+|props|[string]|false|none|none|
+|children|[string]|false|none|none|
+

--- a/reference/README.md
+++ b/reference/README.md
@@ -19,7 +19,9 @@ headingLevel: 2
 
 > Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
 
-manage DtLab actor runtime cloud
+Manage DtLab actor runtime cloud.
+
+DtLab is an actor environment that enables the instantiation of DTs (digital twins) with persistence and messaging and basic schema checking.
 
 Base URLs:
 

--- a/reference/README.md
+++ b/reference/README.md
@@ -30,7 +30,230 @@ Base URLs:
 Email: <a href="mailto:ed@onextent.com">navicore</a> 
 License: <a href="https://github.com/SoMind/dtlab-scala-alligator/blob/master/LICENSE">MIT</a>
 
-<h1 id="dtlab-alligator-create">create</h1>
+<h1 id="dtlab-alligator-ask">ask</h1>
+
+## get-dtlab-alligator-typeId
+
+<a id="opIdget-dtlab-alligator-typeId"></a>
+
+> Code samples
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://localhost:8081/dtlab-alligator/type/{typeId}', headers = headers)
+
+print(r.json())
+
+```
+
+```shell
+# You can also use wget
+curl -X GET http://localhost:8081/dtlab-alligator/type/{typeId} \
+  -H 'Accept: application/json'
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+};
+
+fetch('http://localhost:8081/dtlab-alligator/type/{typeId}',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```java
+URL obj = new URL("http://localhost:8081/dtlab-alligator/type/{typeId}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+`GET /dtlab-alligator/type/{typeId}`
+
+*get type*
+
+Look up a type definition.
+
+<h3 id="get-dtlab-alligator-typeid-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|typeId|path|string|true|the name of the type that can show up in a path|
+
+> Example responses
+
+> Definition of the type
+
+```json
+{
+  "children": [
+    "alternator_module",
+    "starter_module"
+  ],
+  "created": "2020-07-23T01:30:24.783Z",
+  "name": "machinery1",
+  "props": [
+    "temp",
+    "speed"
+  ]
+}
+```
+
+<h3 id="get-dtlab-alligator-typeid-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Definition of the type|[Type](#schematype)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|None|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## get-dtlab-alligator-actorId
+
+<a id="opIdget-dtlab-alligator-actorId"></a>
+
+> Code samples
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
+}
+
+r = requests.get('http://localhost:8081/dtlab-alligator/actor/{typeId}/{instanceId}', headers = headers)
+
+print(r.json())
+
+```
+
+```shell
+# You can also use wget
+curl -X GET http://localhost:8081/dtlab-alligator/actor/{typeId}/{instanceId} \
+  -H 'Accept: application/json'
+
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+};
+
+fetch('http://localhost:8081/dtlab-alligator/actor/{typeId}/{instanceId}',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```java
+URL obj = new URL("http://localhost:8081/dtlab-alligator/actor/{typeId}/{instanceId}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+`GET /dtlab-alligator/actor/{typeId}/{instanceId}`
+
+*get actor*
+
+Look up a the state of an actor.
+
+<h3 id="get-dtlab-alligator-actorid-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|typeId|path|string|true|the name of the type that can show up in a path|
+|instanceId|path|string|true|the id of the instance of the type|
+
+> Example responses
+
+> OK
+
+```json
+[
+  {
+    "datetime": "2020-09-13T15:31:21.671Z",
+    "idx": 0,
+    "value": 2.1
+  },
+  {
+    "datetime": "2020-07-26T17:25:21.803Z",
+    "idx": 1,
+    "value": 2.2
+  }
+]
+```
+
+<h3 id="get-dtlab-alligator-actorid-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|None|
+
+<h3 id="get-dtlab-alligator-actorid-responseschema">Response Schema</h3>
+
+Status Code **200**
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|*anonymous*|[[Telemetry](#schematelemetry)]|false|none|[Telemetry is a time series entity - each change to a DT's state is journaled with a datetime.]|
+|» Telemetry|[Telemetry](#schematelemetry)|false|none|Telemetry is a time series entity - each change to a DT's state is journaled with a datetime.|
+|»» datetime|string|false|none|none|
+|»» idx|integer|true|none|none|
+|»» value|number|true|none|none|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+<h1 id="dtlab-alligator-tell">tell</h1>
 
 ## post-dtlab-alligator-type-typeId
 
@@ -268,229 +491,6 @@ update an actor instance with attached property value indentified by the index o
 |---|---|---|---|
 |202|[Accepted](https://tools.ietf.org/html/rfc7231#section-6.3.3)|Accepted|None|
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Unprocessable Entity (WebDAV)|None|
-
-<aside class="success">
-This operation does not require authentication
-</aside>
-
-<h1 id="dtlab-alligator-ask">ask</h1>
-
-## get-dtlab-alligator-typeId
-
-<a id="opIdget-dtlab-alligator-typeId"></a>
-
-> Code samples
-
-```python
-import requests
-headers = {
-  'Accept': 'application/json'
-}
-
-r = requests.get('http://localhost:8081/dtlab-alligator/type/{typeId}', headers = headers)
-
-print(r.json())
-
-```
-
-```shell
-# You can also use wget
-curl -X GET http://localhost:8081/dtlab-alligator/type/{typeId} \
-  -H 'Accept: application/json'
-
-```
-
-```javascript
-
-const headers = {
-  'Accept':'application/json'
-};
-
-fetch('http://localhost:8081/dtlab-alligator/type/{typeId}',
-{
-  method: 'GET',
-
-  headers: headers
-})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-
-```
-
-```java
-URL obj = new URL("http://localhost:8081/dtlab-alligator/type/{typeId}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-
-```
-
-`GET /dtlab-alligator/type/{typeId}`
-
-*get type*
-
-Look up a type definition.
-
-<h3 id="get-dtlab-alligator-typeid-parameters">Parameters</h3>
-
-|Name|In|Type|Required|Description|
-|---|---|---|---|---|
-|typeId|path|string|true|the name of the type that can show up in a path|
-
-> Example responses
-
-> Definition of the type
-
-```json
-{
-  "children": [
-    "alternator_module",
-    "starter_module"
-  ],
-  "created": "2020-07-23T01:30:24.783Z",
-  "name": "machinery1",
-  "props": [
-    "temp",
-    "speed"
-  ]
-}
-```
-
-<h3 id="get-dtlab-alligator-typeid-responses">Responses</h3>
-
-|Status|Meaning|Description|Schema|
-|---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Definition of the type|[Type](#schematype)|
-|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|None|
-
-<aside class="success">
-This operation does not require authentication
-</aside>
-
-## get-dtlab-alligator-actorId
-
-<a id="opIdget-dtlab-alligator-actorId"></a>
-
-> Code samples
-
-```python
-import requests
-headers = {
-  'Accept': 'application/json'
-}
-
-r = requests.get('http://localhost:8081/dtlab-alligator/actor/{typeId}/{instanceId}', headers = headers)
-
-print(r.json())
-
-```
-
-```shell
-# You can also use wget
-curl -X GET http://localhost:8081/dtlab-alligator/actor/{typeId}/{instanceId} \
-  -H 'Accept: application/json'
-
-```
-
-```javascript
-
-const headers = {
-  'Accept':'application/json'
-};
-
-fetch('http://localhost:8081/dtlab-alligator/actor/{typeId}/{instanceId}',
-{
-  method: 'GET',
-
-  headers: headers
-})
-.then(function(res) {
-    return res.json();
-}).then(function(body) {
-    console.log(body);
-});
-
-```
-
-```java
-URL obj = new URL("http://localhost:8081/dtlab-alligator/actor/{typeId}/{instanceId}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-
-```
-
-`GET /dtlab-alligator/actor/{typeId}/{instanceId}`
-
-*get actor*
-
-Look up a the state of an actor.
-
-<h3 id="get-dtlab-alligator-actorid-parameters">Parameters</h3>
-
-|Name|In|Type|Required|Description|
-|---|---|---|---|---|
-|typeId|path|string|true|the name of the type that can show up in a path|
-|instanceId|path|string|true|the id of the instance of the type|
-
-> Example responses
-
-> OK
-
-```json
-[
-  {
-    "datetime": "2020-09-13T15:31:21.671Z",
-    "idx": 0,
-    "value": 2.1
-  },
-  {
-    "datetime": "2020-07-26T17:25:21.803Z",
-    "idx": 1,
-    "value": 2.2
-  }
-]
-```
-
-<h3 id="get-dtlab-alligator-actorid-responses">Responses</h3>
-
-|Status|Meaning|Description|Schema|
-|---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|Inline|
-|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|None|
-
-<h3 id="get-dtlab-alligator-actorid-responseschema">Response Schema</h3>
-
-Status Code **200**
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|*anonymous*|[[Telemetry](#schematelemetry)]|false|none|[Telemetry is a time series entity - each change to a DT's state is journaled with a datetime.]|
-|» Telemetry|[Telemetry](#schematelemetry)|false|none|Telemetry is a time series entity - each change to a DT's state is journaled with a datetime.|
-|»» datetime|string|false|none|none|
-|»» idx|integer|true|none|none|
-|»» value|number|true|none|none|
 
 <aside class="success">
 This operation does not require authentication

--- a/reference/README.md
+++ b/reference/README.md
@@ -32,9 +32,9 @@ License: <a href="https://github.com/SoMind/dtlab-scala-alligator/blob/master/LI
 
 <h1 id="dtlab-alligator-create">create</h1>
 
-## post-dtlab-alligator-type-typename
+## post-dtlab-alligator-type-typeId
 
-<a id="opIdpost-dtlab-alligator-type-typename"></a>
+<a id="opIdpost-dtlab-alligator-type-typeId"></a>
 
 > Code samples
 
@@ -45,7 +45,7 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.post('http://localhost:8081/dtlab-alligator/type/{typename}', headers = headers)
+r = requests.post('http://localhost:8081/dtlab-alligator/type/{typeId}', headers = headers)
 
 print(r.json())
 
@@ -53,7 +53,7 @@ print(r.json())
 
 ```shell
 # You can also use wget
-curl -X POST http://localhost:8081/dtlab-alligator/type/{typename} \
+curl -X POST http://localhost:8081/dtlab-alligator/type/{typeId} \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json'
 
@@ -75,7 +75,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('http://localhost:8081/dtlab-alligator/type/{typename}',
+fetch('http://localhost:8081/dtlab-alligator/type/{typeId}',
 {
   method: 'POST',
   body: inputBody,
@@ -90,7 +90,7 @@ fetch('http://localhost:8081/dtlab-alligator/type/{typename}',
 ```
 
 ```java
-URL obj = new URL("http://localhost:8081/dtlab-alligator/type/{typename}");
+URL obj = new URL("http://localhost:8081/dtlab-alligator/type/{typeId}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("POST");
 int responseCode = con.getResponseCode();
@@ -106,7 +106,7 @@ System.out.println(response.toString());
 
 ```
 
-`POST /dtlab-alligator/type/{typename}`
+`POST /dtlab-alligator/type/{typeId}`
 
 *create type*
 
@@ -127,38 +127,147 @@ create a new type with property names and allowable children types
 }
 ```
 
-<h3 id="post-dtlab-alligator-type-typename-parameters">Parameters</h3>
+<h3 id="post-dtlab-alligator-type-typeid-parameters">Parameters</h3>
 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
-|body|body|[CreateTypeRequest](#schemacreatetyperequest)|false|a copy of the successfully created type definition|
-|typename|path|string|true|the name of the type that can show up in a path|
+|body|body|[Type](#schematype)|false|a copy of the successfully created type definition|
+|typeId|path|string|true|the name of the type that can show up in a path|
 
 > Example responses
 
-> 201 Response
+> If successfully created, returned object will be updated with typeId and create datetime
 
 ```json
 {
-  "name": "string",
-  "created": "string",
-  "props": [
-    "string"
-  ],
   "children": [
-    "string"
+    "alternator_module",
+    "starter_module"
+  ],
+  "created": "2020-07-26T18:09:06.592Z",
+  "name": "machinery66",
+  "props": [
+    "temp",
+    "speed"
   ]
 }
 ```
 
-<h3 id="post-dtlab-alligator-type-typename-responses">Responses</h3>
+> 409 Response
+
+```json
+{}
+```
+
+<h3 id="post-dtlab-alligator-type-typeid-responses">Responses</h3>
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
-|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|If successfully created, returned object will be updated with typename and create datetime|[Type](#schematype)|
+|201|[Created](https://tools.ietf.org/html/rfc7231#section-6.3.2)|If successfully created, returned object will be updated with typeId and create datetime|[Type](#schematype)|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict - you must delete the previous entry before creating a type of the same name.|Inline|
 
-<h3 id="post-dtlab-alligator-type-typename-responseschema">Response Schema</h3>
+<h3 id="post-dtlab-alligator-type-typeid-responseschema">Response Schema</h3>
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+## post-dtlab-alligator-type-actorId
+
+<a id="opIdpost-dtlab-alligator-type-actorId"></a>
+
+> Code samples
+
+```python
+import requests
+headers = {
+  'Content-Type': 'application/json'
+}
+
+r = requests.post('http://localhost:8081/dtlab-alligator/actor/{typeId}/{instanceId}', headers = headers)
+
+print(r.json())
+
+```
+
+```shell
+# You can also use wget
+curl -X POST http://localhost:8081/dtlab-alligator/actor/{typeId}/{instanceId} \
+  -H 'Content-Type: application/json'
+
+```
+
+```javascript
+const inputBody = '{
+  "datetime": "string",
+  "idx": 0,
+  "value": 0
+}';
+const headers = {
+  'Content-Type':'application/json'
+};
+
+fetch('http://localhost:8081/dtlab-alligator/actor/{typeId}/{instanceId}',
+{
+  method: 'POST',
+  body: inputBody,
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```java
+URL obj = new URL("http://localhost:8081/dtlab-alligator/actor/{typeId}/{instanceId}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("POST");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+`POST /dtlab-alligator/actor/{typeId}/{instanceId}`
+
+*update a single actor property*
+
+update an actor instance with attached property value indentified by the index of the property in the typeId
+
+> Body parameter
+
+```json
+{
+  "datetime": "string",
+  "idx": 0,
+  "value": 0
+}
+```
+
+<h3 id="post-dtlab-alligator-type-actorid-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[Telemetry](#schematelemetry)|false|The value of the property to upate identified by its index in its type definition.|
+|typeId|path|string|true|the name of the type that can show up in a path|
+|instanceId|path|string|true|the id of the instance of the type|
+
+<h3 id="post-dtlab-alligator-type-actorid-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|202|[Accepted](https://tools.ietf.org/html/rfc7231#section-6.3.3)|Accepted|None|
+|422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Unprocessable Entity (WebDAV)|None|
 
 <aside class="success">
 This operation does not require authentication
@@ -166,9 +275,9 @@ This operation does not require authentication
 
 <h1 id="dtlab-alligator-ask">ask</h1>
 
-## get-dtlab-alligator-typename
+## get-dtlab-alligator-typeId
 
-<a id="opIdget-dtlab-alligator-typename"></a>
+<a id="opIdget-dtlab-alligator-typeId"></a>
 
 > Code samples
 
@@ -178,7 +287,7 @@ headers = {
   'Accept': 'application/json'
 }
 
-r = requests.get('http://localhost:8081/dtlab-alligator/type/{typename}', headers = headers)
+r = requests.get('http://localhost:8081/dtlab-alligator/type/{typeId}', headers = headers)
 
 print(r.json())
 
@@ -186,7 +295,7 @@ print(r.json())
 
 ```shell
 # You can also use wget
-curl -X GET http://localhost:8081/dtlab-alligator/type/{typename} \
+curl -X GET http://localhost:8081/dtlab-alligator/type/{typeId} \
   -H 'Accept: application/json'
 
 ```
@@ -197,7 +306,7 @@ const headers = {
   'Accept':'application/json'
 };
 
-fetch('http://localhost:8081/dtlab-alligator/type/{typename}',
+fetch('http://localhost:8081/dtlab-alligator/type/{typeId}',
 {
   method: 'GET',
 
@@ -212,7 +321,7 @@ fetch('http://localhost:8081/dtlab-alligator/type/{typename}',
 ```
 
 ```java
-URL obj = new URL("http://localhost:8081/dtlab-alligator/type/{typename}");
+URL obj = new URL("http://localhost:8081/dtlab-alligator/type/{typeId}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
 int responseCode = con.getResponseCode();
@@ -228,17 +337,17 @@ System.out.println(response.toString());
 
 ```
 
-`GET /dtlab-alligator/type/{typename}`
+`GET /dtlab-alligator/type/{typeId}`
 
 *get type*
 
 Look up a type definition.
 
-<h3 id="get-dtlab-alligator-typename-parameters">Parameters</h3>
+<h3 id="get-dtlab-alligator-typeid-parameters">Parameters</h3>
 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
-|typename|path|string|true|the name of the type that can show up in a path|
+|typeId|path|string|true|the name of the type that can show up in a path|
 
 > Example responses
 
@@ -259,7 +368,7 @@ Look up a type definition.
 }
 ```
 
-<h3 id="get-dtlab-alligator-typename-responses">Responses</h3>
+<h3 id="get-dtlab-alligator-typeid-responses">Responses</h3>
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
@@ -270,35 +379,124 @@ Look up a type definition.
 This operation does not require authentication
 </aside>
 
-# Schemas
+## get-dtlab-alligator-actorId
 
-<h2 id="tocS_CreateTypeRequest">CreateTypeRequest</h2>
-<!-- backwards compatibility -->
-<a id="schemacreatetyperequest"></a>
-<a id="schema_CreateTypeRequest"></a>
-<a id="tocScreatetyperequest"></a>
-<a id="tocscreatetyperequest"></a>
+<a id="opIdget-dtlab-alligator-actorId"></a>
 
-```json
-{
-  "props": [
-    "string"
-  ],
-  "children": [
-    "string"
-  ]
+> Code samples
+
+```python
+import requests
+headers = {
+  'Accept': 'application/json'
 }
+
+r = requests.get('http://localhost:8081/dtlab-alligator/actor/{typeId}/{instanceId}', headers = headers)
+
+print(r.json())
 
 ```
 
-CreateTypeRequest
+```shell
+# You can also use wget
+curl -X GET http://localhost:8081/dtlab-alligator/actor/{typeId}/{instanceId} \
+  -H 'Accept: application/json'
 
-### Properties
+```
+
+```javascript
+
+const headers = {
+  'Accept':'application/json'
+};
+
+fetch('http://localhost:8081/dtlab-alligator/actor/{typeId}/{instanceId}',
+{
+  method: 'GET',
+
+  headers: headers
+})
+.then(function(res) {
+    return res.json();
+}).then(function(body) {
+    console.log(body);
+});
+
+```
+
+```java
+URL obj = new URL("http://localhost:8081/dtlab-alligator/actor/{typeId}/{instanceId}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+`GET /dtlab-alligator/actor/{typeId}/{instanceId}`
+
+*get actor*
+
+Look up a the state of an actor.
+
+<h3 id="get-dtlab-alligator-actorid-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|typeId|path|string|true|the name of the type that can show up in a path|
+|instanceId|path|string|true|the id of the instance of the type|
+
+> Example responses
+
+> OK
+
+```json
+[
+  {
+    "datetime": "2020-09-13T15:31:21.671Z",
+    "idx": 0,
+    "value": 2.1
+  },
+  {
+    "datetime": "2020-07-26T17:25:21.803Z",
+    "idx": 1,
+    "value": 2.2
+  }
+]
+```
+
+<h3 id="get-dtlab-alligator-actorid-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|None|
+
+<h3 id="get-dtlab-alligator-actorid-responseschema">Response Schema</h3>
+
+Status Code **200**
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|props|[string]|false|none|none|
-|children|[string]|false|none|none|
+|*anonymous*|[[Telemetry](#schematelemetry)]|false|none|[Telemetry is a time series entity - each change to a DT's state is journaled with a datetime.]|
+|» Telemetry|[Telemetry](#schematelemetry)|false|none|Telemetry is a time series entity - each change to a DT's state is journaled with a datetime.|
+|»» datetime|string|false|none|none|
+|»» idx|integer|true|none|none|
+|»» value|number|true|none|none|
+
+<aside class="success">
+This operation does not require authentication
+</aside>
+
+# Schemas
 
 <h2 id="tocS_Type">Type</h2>
 <!-- backwards compatibility -->
@@ -331,4 +529,30 @@ Type
 |created|string|false|none|none|
 |props|[string]|false|none|none|
 |children|[string]|false|none|none|
+
+<h2 id="tocS_Telemetry">Telemetry</h2>
+<!-- backwards compatibility -->
+<a id="schematelemetry"></a>
+<a id="schema_Telemetry"></a>
+<a id="tocStelemetry"></a>
+<a id="tocstelemetry"></a>
+
+```json
+{
+  "datetime": "string",
+  "idx": 0,
+  "value": 0
+}
+
+```
+
+Telemetry
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|datetime|string|false|none|none|
+|idx|integer|true|none|none|
+|value|number|true|none|none|
 

--- a/reference/README.md
+++ b/reference/README.md
@@ -204,7 +204,7 @@ System.out.println(response.toString());
 
 Look up a the state of an actor.
 
-Note that OpenAPI 3.0 does not support repeating path components that are very natural in REST.  So know that DtPaths in DtLab support deeper parent child paths than the spec creates examples for.  `/dtlab-alligator/actor/{grandParentTypeId}/{grandParentInstanceId}/{parentTypeId}/{parentInstanceId}/{typeId}/{instanceId}` is valid.
+Note that OpenAPI 3.0 does not support repeating path components that are very natural in REST.  They feel variable numbers of segments means they are optional - they are not optional at all in the DtLab system.  They are the way to point to the resource, making them correct use of path segments.  The OpenAPI team's solution to turn the segents into query params is hacky and not followed here.  To document a path for every supported level of parent / child relations would create massive duplication of documentation.  So know that DtPaths in DtLab support deeper parent child paths than the spec creates examples for.  `/dtlab-alligator/actor/{grandParentTypeId}/{grandParentInstanceId}/{parentTypeId}/{parentInstanceId}/{typeId}/{instanceId}` is valid.
 
 <h3 id="get-dtlab-alligator-actorid-parameters">Parameters</h3>
 
@@ -467,9 +467,9 @@ System.out.println(response.toString());
 
 *update a single actor property*
 
-update an actor instance with attached property value indentified by the index of the property in the typeId
+Update an actor instance with attached property value indentified by the index of the property in the typeId.
 
-Note that OpenAPI 3.0 does not support repeating path components that are very natural in REST.  So know that DtPaths in DtLab support deeper parent child paths than the spec creates examples for.  `/dtlab-alligator/actor/{grandParentTypeId}/{grandParentInstanceId}/{parentTypeId}/{parentInstanceId}/{typeId}/{instanceId}` is valid.
+Note that OpenAPI 3.0 does not support repeating path components that are very natural in REST.  They feel variable numbers of segments means they are optional - they are not optional at all in the DtLab system.  They are the way to point to the resource, making them correct use of path segments.  The OpenAPI team's solution to turn the segents into query params is hacky and not followed here.  To document a path for every supported level of parent / child relations would create massive duplication of documentation.  So know that DtPaths in DtLab support deeper parent child paths than the spec creates examples for.  `/dtlab-alligator/actor/{grandParentTypeId}/{grandParentInstanceId}/{parentTypeId}/{parentInstanceId}/{typeId}/{instanceId}` is valid.
 
 > Body parameter
 

--- a/reference/README.md
+++ b/reference/README.md
@@ -469,6 +469,8 @@ System.out.println(response.toString());
 
 update an actor instance with attached property value indentified by the index of the property in the typeId
 
+Note that OpenAPI 3.0 does not support repeating path components that are very natural in REST.  So know that DtPaths in DtLab support deeper parent child paths than the spec creates examples for.  `/dtlab-alligator/actor/{grandParentTypeId}/{grandParentInstanceId}/{parentTypeId}/{parentInstanceId}/{typeId}/{instanceId}` is valid.
+
 > Body parameter
 
 ```json

--- a/reference/README.md
+++ b/reference/README.md
@@ -204,6 +204,8 @@ System.out.println(response.toString());
 
 Look up a the state of an actor.
 
+Note that OpenAPI 3.0 does not support repeating path components that are very natural in REST.  So know that DtPaths in DtLab support deeper parent child paths than the spec creates examples for.  `/dtlab-alligator/actor/{grandParentTypeId}/{grandParentInstanceId}/{parentTypeId}/{parentInstanceId}/{typeId}/{instanceId}` is valid.
+
 <h3 id="get-dtlab-alligator-actorid-parameters">Parameters</h3>
 
 |Name|In|Type|Required|Description|

--- a/reference/dtlab-alligator.v1.yaml
+++ b/reference/dtlab-alligator.v1.yaml
@@ -28,7 +28,6 @@ paths:
     post:
       summary: create type
       tags:
-        - create
         - tell
       responses:
         '201':
@@ -118,7 +117,6 @@ paths:
     post:
       summary: update a single actor property
       tags:
-        - create
         - tell
       responses:
         '202':

--- a/reference/dtlab-alligator.v1.yaml
+++ b/reference/dtlab-alligator.v1.yaml
@@ -125,9 +125,9 @@ paths:
           description: Unprocessable Entity (WebDAV)
       operationId: post-dtlab-alligator-type-actorId
       description: |-
-        update an actor instance with attached property value indentified by the index of the property in the typeId
+        Update an actor instance with attached property value indentified by the index of the property in the typeId.
 
-        Note that OpenAPI 3.0 does not support repeating path components that are very natural in REST.  So know that DtPaths in DtLab support deeper parent child paths than the spec creates examples for.  `/dtlab-alligator/actor/{grandParentTypeId}/{grandParentInstanceId}/{parentTypeId}/{parentInstanceId}/{typeId}/{instanceId}` is valid.
+        Note that OpenAPI 3.0 does not support repeating path components that are very natural in REST.  They feel variable numbers of segments means they are optional - they are not optional at all in the DtLab system.  They are the way to point to the resource, making them correct use of path segments.  The OpenAPI team's solution to turn the segents into query params is hacky and not followed here.  To document a path for every supported level of parent / child relations would create massive duplication of documentation.  So know that DtPaths in DtLab support deeper parent child paths than the spec creates examples for.  `/dtlab-alligator/actor/{grandParentTypeId}/{grandParentInstanceId}/{parentTypeId}/{parentInstanceId}/{typeId}/{instanceId}` is valid.
       requestBody:
         content:
           application/json:
@@ -162,7 +162,7 @@ paths:
       description: |-
         Look up a the state of an actor.
 
-        Note that OpenAPI 3.0 does not support repeating path components that are very natural in REST.  So know that DtPaths in DtLab support deeper parent child paths than the spec creates examples for.  `/dtlab-alligator/actor/{grandParentTypeId}/{grandParentInstanceId}/{parentTypeId}/{parentInstanceId}/{typeId}/{instanceId}` is valid.
+        Note that OpenAPI 3.0 does not support repeating path components that are very natural in REST.  They feel variable numbers of segments means they are optional - they are not optional at all in the DtLab system.  They are the way to point to the resource, making them correct use of path segments.  The OpenAPI team's solution to turn the segents into query params is hacky and not followed here.  To document a path for every supported level of parent / child relations would create massive duplication of documentation.  So know that DtPaths in DtLab support deeper parent child paths than the spec creates examples for.  `/dtlab-alligator/actor/{grandParentTypeId}/{grandParentInstanceId}/{parentTypeId}/{parentInstanceId}/{typeId}/{instanceId}` is valid.
 components:
   schemas:
     Type:

--- a/reference/dtlab-alligator.v1.yaml
+++ b/reference/dtlab-alligator.v1.yaml
@@ -124,7 +124,10 @@ paths:
         '422':
           description: Unprocessable Entity (WebDAV)
       operationId: post-dtlab-alligator-type-actorId
-      description: update an actor instance with attached property value indentified by the index of the property in the typeId
+      description: |-
+        update an actor instance with attached property value indentified by the index of the property in the typeId
+
+        Note that OpenAPI 3.0 does not support repeating path components that are very natural in REST.  So know that DtPaths in DtLab support deeper parent child paths than the spec creates examples for.  `/dtlab-alligator/actor/{grandParentTypeId}/{grandParentInstanceId}/{parentTypeId}/{parentInstanceId}/{typeId}/{instanceId}` is valid.
       requestBody:
         content:
           application/json:

--- a/reference/dtlab-alligator.v1.yaml
+++ b/reference/dtlab-alligator.v1.yaml
@@ -16,12 +16,12 @@ servers:
   - url: 'http://localhost:8081'
     description: dev local mode
 paths:
-  '/dtlab-alligator/type/{typename}':
+  '/dtlab-alligator/type/{typeId}':
     parameters:
       - schema:
           type: string
           example: machinery
-        name: typename
+        name: typeId
         in: path
         description: the name of the type that can show up in a path
         required: true
@@ -32,11 +32,22 @@ paths:
         - tell
       responses:
         '201':
-          description: 'If successfully created, returned object will be updated with typename and create datetime'
+          description: 'If successfully created, returned object will be updated with typeId and create datetime'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Type'
+              examples:
+                example-1:
+                  value:
+                    children:
+                      - alternator_module
+                      - starter_module
+                    created: '2020-07-26T18:09:06.592Z'
+                    name: machinery66
+                    props:
+                      - temp
+                      - speed
         '409':
           description: Conflict - you must delete the previous entry before creating a type of the same name.
           content:
@@ -44,13 +55,13 @@ paths:
               schema:
                 type: object
                 properties: {}
-      operationId: post-dtlab-alligator-type-typename
+      operationId: post-dtlab-alligator-type-typeId
       description: create a new type with property names and allowable children types
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateTypeRequest'
+              $ref: '#/components/schemas/Type'
             examples:
               example-1:
                 value:
@@ -86,34 +97,84 @@ paths:
                       - speed
         '404':
           description: Not Found
-      operationId: get-dtlab-alligator-typename
+      operationId: get-dtlab-alligator-typeId
       description: Look up a type definition.
+  '/dtlab-alligator/actor/{typeId}/{instanceId}':
+    parameters:
+      - schema:
+          type: string
+          example: machinery
+        name: typeId
+        in: path
+        description: the name of the type that can show up in a path
+        required: true
+      - schema:
+          type: string
+          example: module0091
+        name: instanceId
+        in: path
+        description: the id of the instance of the type
+        required: true
+    post:
+      summary: update a single actor property
+      tags:
+        - create
+        - tell
+      responses:
+        '202':
+          description: Accepted
+        '422':
+          description: Unprocessable Entity (WebDAV)
+      operationId: post-dtlab-alligator-type-actorId
+      description: update an actor instance with attached property value indentified by the index of the property in the typeId
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Telemetry'
+        description: The value of the property to upate identified by its index in its type definition.
+    get:
+      summary: get actor
+      tags:
+        - ask
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Telemetry'
+              examples:
+                example-1:
+                  value:
+                    - datetime: '2020-09-13T15:31:21.671Z'
+                      idx: 0
+                      value: 2.1
+                    - datetime: '2020-07-26T17:25:21.803Z'
+                      idx: 1
+                      value: 2.2
+        '404':
+          description: Not Found
+      operationId: get-dtlab-alligator-actorId
+      description: Look up a the state of an actor.
 components:
   schemas:
-    CreateTypeRequest:
-      title: CreateTypeRequest
-      type: object
-      properties:
-        props:
-          type: array
-          items:
-            type: string
-        children:
-          type: array
-          items:
-            type: string
-      x-examples:
-        example-1:
-          props:
-            - temp
-            - speed
-          children:
-            - alternator_module
-            - starter_module
-      description: Data needed to create new type
     Type:
       title: Type
       type: object
+      x-examples:
+        example-1:
+          children:
+            - alternator_module
+            - starter_module
+          created: '2020-07-23T01:30:24.783Z'
+          name: machinery
+          props:
+            - temp
+            - speed
+      description: "Constrains digital twins to have certain properties and children of certain types.  \n\nA type can be recursive and also show up in multiple locations in a DT tree / graph."
       properties:
         name:
           type: string
@@ -127,17 +188,28 @@ components:
           type: array
           items:
             type: string
+    Telemetry:
+      title: Telemetry
+      type: object
+      properties:
+        datetime:
+          type: string
+        idx:
+          type: integer
+        value:
+          type: number
+      required:
+        - idx
+        - value
+      description: "Telemetry is a time series entity - each change to a DT's state is journaled with a datetime."
       x-examples:
         example-1:
-          children:
-            - alternator_module
-            - starter_module
-          created: '2020-07-23T01:30:24.783Z'
-          name: machinery
-          props:
-            - temp
-            - speed
-      description: "Constrains digital twins to have certain properties and children of certain types.  \n\nA type can be recursive and also show up in multiple locations in a DT tree / graph."
+          idx: 0
+          value: 2.1
+          datetime: '2020-09-13T15:31:21.671Z'
+        example-2:
+          idx: 1
+          value: 2.2
 tags:
   - name: create
   - name: delete

--- a/reference/dtlab-alligator.v1.yaml
+++ b/reference/dtlab-alligator.v1.yaml
@@ -8,7 +8,10 @@ info:
   license:
     name: MIT
     url: 'https://github.com/SoMind/dtlab-scala-alligator/blob/master/LICENSE'
-  description: manage DtLab actor runtime cloud
+  description: |-
+    Manage DtLab actor runtime cloud.
+
+    DtLab is an actor environment that enables the instantiation of DTs (digital twins) with persistence and messaging and basic schema checking.
 servers:
   - url: 'http://localhost:8081'
     description: dev local mode
@@ -60,10 +63,9 @@ paths:
         description: a copy of the successfully created type definition
     get:
       summary: get type
-      tags: [ask]
+      tags:
+        - ask
       responses:
-        '404':
-          description: Not Found
         '200':
           description: Definition of the type
           headers: {}
@@ -82,6 +84,8 @@ paths:
                     props:
                       - temp
                       - speed
+        '404':
+          description: Not Found
       operationId: get-dtlab-alligator-typename
       description: Look up a type definition.
 components:
@@ -133,7 +137,7 @@ components:
           props:
             - temp
             - speed
-      description: Constrains digital twins to have certain properties and children of certain types.  A type can be recursive and also show up in multiple locations in a DT tree / graph
+      description: "Constrains digital twins to have certain properties and children of certain types.  \n\nA type can be recursive and also show up in multiple locations in a DT tree / graph."
 tags:
   - name: create
   - name: delete

--- a/reference/dtlab-alligator.v1.yaml
+++ b/reference/dtlab-alligator.v1.yaml
@@ -156,7 +156,10 @@ paths:
         '404':
           description: Not Found
       operationId: get-dtlab-alligator-actorId
-      description: Look up a the state of an actor.
+      description: |-
+        Look up a the state of an actor.
+
+        Note that OpenAPI 3.0 does not support repeating path components that are very natural in REST.  So know that DtPaths in DtLab support deeper parent child paths than the spec creates examples for.  `/dtlab-alligator/actor/{grandParentTypeId}/{grandParentInstanceId}/{parentTypeId}/{parentInstanceId}/{typeId}/{instanceId}` is valid.
 components:
   schemas:
     Type:

--- a/reference/env.json
+++ b/reference/env.json
@@ -1,0 +1,3 @@
+{
+"language_tabs": [{ "python": "Python" }, { "shell": "Shell" }, {"javascript": "Javascript"}, {"java": "Java"}]
+}


### PR DESCRIPTION
Note that OpenAPI 3.0 does not support repeating path components that are very natural in REST.  They feel variable numbers of segments means they are optional - they are not optional at all in the DtLab system.  They are the way to point to the resource, making them correct use of path segments.  The OpenAPI team's solution to turn the segents into query params is hacky and not followed here.  To document a path for every supported level of parent / child relations would create massive duplication of documentation.  So know that DtPaths in DtLab support deeper parent child paths than the spec creates examples for.  `/dtlab-alligator/actor/{grandParentTypeId}/{grandParentInstanceId}/{parentTypeId}/{parentInstanceId}/{typeId}/{instanceId}` is valid.